### PR TITLE
Tidied output when error is detected

### DIFF
--- a/command/helpers/common.go
+++ b/command/helpers/common.go
@@ -114,7 +114,7 @@ func DisplayOutput(data []byte, rawjson bool) {
         if mymap["result"] == "ok" && len(mymap["data"].(map[string]interface{})) == 0 {
             fmt.Println(mymap["result"])
         } else if mymap["result"] == "error" {
-            fmt.Println("ERROR\n")
+            fmt.Println("ERROR")
             fmt.Println(mymap["message"])
         } else {
             x := bytes.Buffer{}

--- a/command/helpers/common.go
+++ b/command/helpers/common.go
@@ -110,9 +110,17 @@ func DisplayOutput(data []byte, rawjson bool) {
     if rawjson {
         fmt.Println(string(data))
     } else {
-        x := bytes.Buffer{}
-        json.Indent(&x, data, "", "    ")
-        fmt.Println(string(x.Bytes()))
+        mymap := ByteArrayToMap(data)
+        if mymap["result"] == "ok" && len(mymap["data"].(map[string]interface{})) == 0 {
+            fmt.Println(mymap["result"])
+        } else if mymap["result"] == "error" {
+            fmt.Println("ERROR\n")
+            fmt.Println(mymap["message"])
+        } else {
+            x := bytes.Buffer{}
+            json.Indent(&x, data, "", "    ")
+            fmt.Println(string(x.Bytes()))
+        }
     }
 }
 
@@ -151,8 +159,7 @@ func ExecCommand(basepath string, endpoint string, serverOverride string, get bo
         DisplayOutput(data, RawJSON)
     }
     responseMap := ByteArrayToMap(response)
-    result := responseMap["result"]
-    if result != "ok" {
+    if responseMap["result"] != "ok" {
         os.Exit(10)
     }
 }


### PR DESCRIPTION
Labelled as breaking as now ok with NO data just returns "ok" and error messages are no longer processed as json.

To get guaranteed json output --rawjson is now required.