### PR TITLE
Release 1.2

### DIFF
--- a/command/helpers/common.go
+++ b/command/helpers/common.go
@@ -110,9 +110,17 @@ func DisplayOutput(data []byte, rawjson bool) {
     if rawjson {
         fmt.Println(string(data))
     } else {
-        x := bytes.Buffer{}
-        json.Indent(&x, data, "", "    ")
-        fmt.Println(string(x.Bytes()))
+        mymap := ByteArrayToMap(data)
+        if mymap["result"] == "ok" && len(mymap["data"].(map[string]interface{})) == 0 {
+            fmt.Println(mymap["result"])
+        } else if mymap["result"] == "error" {
+            fmt.Println("ERROR")
+            fmt.Println(mymap["message"])
+        } else {
+            x := bytes.Buffer{}
+            json.Indent(&x, data, "", "    ")
+            fmt.Println(string(x.Bytes()))
+        }
     }
 }
 
@@ -151,8 +159,7 @@ func ExecCommand(basepath string, endpoint string, serverOverride string, get bo
         DisplayOutput(data, RawJSON)
     }
     responseMap := ByteArrayToMap(response)
-    result := responseMap["result"]
-    if result != "ok" {
+    if responseMap["result"] != "ok" {
         os.Exit(10)
     }
 }

--- a/commands.go
+++ b/commands.go
@@ -41,7 +41,7 @@ var Commands = []cli.Command{
     {
         Name:   "supervisor",
         Usage:  "info, logs, reload, update",
-        Aliases: []string{"s"},
+        Aliases: []string{"su"},
         Action: command.CmdSupervisor,
         Flags:  []cli.Flag{
             cli.BoolFlag{
@@ -81,7 +81,7 @@ var Commands = []cli.Command{
     {
         Name:   "network",
         Usage:  "info, options",
-        Aliases: []string{"net"},
+        Aliases: []string{"ne"},
         Action: command.CmdNetwork,
         Flags:  []cli.Flag{
             cli.BoolFlag{
@@ -101,7 +101,7 @@ var Commands = []cli.Command{
     {
         Name:   "snapshots",
         Usage:  "list, info, reload, new, restore, remove",
-        Aliases: []string{"snap"},
+        Aliases: []string{"sn"},
         Action: command.CmdSnapshots,
         Flags:  []cli.Flag{
             cli.BoolFlag{

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@ package main
 // Name the name of the CLI
 const Name string = "hassio"
 // Version the current version of the CLI
-const Version string = "1.2.0Dev"
+const Version string = "1.2.0"

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@ package main
 // Name the name of the CLI
 const Name string = "hassio"
 // Version the current version of the CLI
-const Version string = "1.1.2"
+const Version string = "1.2.0Dev"


### PR DESCRIPTION
* Output cleanup -> This may break scripts that depended on default output being json, this was a by product historically. The only _supported_ way to get json is to use --rawjson

* Fixed shortnames for commands to be consistant -> This will break scripts using shortnames in some instances. Shortnames are *not* supported for scripting use the full command name in scripts, short forms are there purely for the user at the cli. 