### PR TITLE
Fix "panic: interface conversion: interface is nil, not string" in Di…

### DIFF
--- a/command/helpers/common.go
+++ b/command/helpers/common.go
@@ -115,7 +115,7 @@ func DisplayOutput(data []byte, rawjson bool) {
             fmt.Println(mymap["result"])
         } else if mymap["result"] == "error" {
             os.Stderr.WriteString("ERROR\n")
-            fmt.Fprintf(os.Stderr, "%s\n", mymap["message"].(string))
+            fmt.Fprintf(os.Stderr, "%v\n", mymap["message"])
         } else {
             x := bytes.Buffer{}
             json.Indent(&x, data, "", "    ")


### PR DESCRIPTION
…splayOutput

Change from %s and a blind string type assertion to the much safer %v that will handle whatever the value of mymap["message"] is.

Addresses symptoms of #87 and #98 , but probably does not resolve the underlying error.