### PR TITLE
Replace log output with logger

### DIFF
--- a/command/addons.go
+++ b/command/addons.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -15,8 +16,6 @@ func CmdAddons(c *cli.Context) {
 	endpoint := ""
 	serverOverride := ""
 	get := false
-	DebugEnabled := c.GlobalBool("debug")
-	helpers.DebugEnabled = DebugEnabled
 	Options := c.String("options")
 	RawJSON := c.Bool("rawjson")
 	Filter := c.String("filter")
@@ -57,10 +56,9 @@ func CmdAddons(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [addons]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-			action, endpoint, serverOverride, get, Options, RawJSON, Filter)
-	}
+	log.Debugf("[addons]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
+		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
+
 	if endpoint != "" || action == "list" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)
 	}

--- a/command/addons.go
+++ b/command/addons.go
@@ -56,8 +56,15 @@ func CmdAddons(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	log.Debugf("[addons]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
+	log.WithFields(log.Fields{
+		"action":         action,
+		"endpoint":       endpoint,
+		"serverOverride": serverOverride,
+		"get":            get,
+		"options":        Options,
+		"rawJSON":        RawJSON,
+		"filter":         Filter,
+	}).Debug("[addons]")
 
 	if endpoint != "" || action == "list" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/hardware.go
+++ b/command/hardware.go
@@ -33,8 +33,15 @@ func CmdHardware(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	log.Debugf("[CmdHardware]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
+	log.WithFields(log.Fields{
+		"action":         action,
+		"endpoint":       endpoint,
+		"serverOverride": serverOverride,
+		"get":            get,
+		"options":        Options,
+		"rawjson":        RawJSON,
+		"filter":         Filter,
+	}).Debug("[CmdHardware]")
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/hardware.go
+++ b/command/hardware.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -15,8 +16,6 @@ func CmdHardware(c *cli.Context) {
 	endpoint := ""
 	serverOverride := ""
 	get := false
-	DebugEnabled := c.GlobalBool("debug")
-	helpers.DebugEnabled = DebugEnabled
 	Options := ""
 	RawJSON := c.Bool("rawjson")
 	Filter := c.String("filter")
@@ -34,10 +33,8 @@ func CmdHardware(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [CmdHardware]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-			action, endpoint, serverOverride, get, Options, RawJSON, Filter)
-	}
+	log.Debugf("[CmdHardware]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
+		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/hassos.go
+++ b/command/hassos.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -15,8 +16,6 @@ func CmdHassOS(c *cli.Context) {
 	endpoint := ""
 	serverOverride := ""
 	get := false
-	DebugEnabled := c.GlobalBool("debug")
-	helpers.DebugEnabled = DebugEnabled
 	Options := c.String("options")
 	RawJSON := c.Bool("rawjson")
 	Filter := c.String("filter")
@@ -33,10 +32,8 @@ func CmdHassOS(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [CmdHost]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-			action, endpoint, serverOverride, get, Options, RawJSON, Filter)
-	}
+	log.Debugf("[CmdHost]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
+		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/hassos.go
+++ b/command/hassos.go
@@ -32,8 +32,15 @@ func CmdHassOS(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	log.Debugf("[CmdHost]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
+	log.WithFields(log.Fields{
+		"action":         action,
+		"endpoint":       endpoint,
+		"serverOverride": serverOverride,
+		"get":            get,
+		"options":        Options,
+		"rawjson":        RawJSON,
+		"filter":         Filter,
+	}).Debug("[CmdHost]")
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/helpers/common.go
+++ b/command/helpers/common.go
@@ -17,7 +17,11 @@ const HassioServer = "hassio"
 
 // GenerateURI Creates the API URI from the server and the endpoint
 func GenerateURI(basepath string, endpoint string, serverOverride string) string {
-	log.Debugf("[GenerateURI]: basepath->'%s', endpoint->'%s', serverOverride->'%s'\n", basepath, endpoint, serverOverride)
+	log.WithFields(log.Fields{
+		"basepath":       basepath,
+		"endpoint":       endpoint,
+		"serverOverride": serverOverride,
+	}).Debug("[GenerateURI]")
 	var uri bytes.Buffer
 	uri.WriteString("http://")
 	if serverOverride != "" {
@@ -37,7 +41,9 @@ func GenerateURI(basepath string, endpoint string, serverOverride string) string
 }
 
 func CreateJSONData(data string) map[string]string {
-	log.Debugf("[CreateJSONData]: data->'%s'\n", data)
+	log.WithFields(log.Fields{
+		"data": data,
+	}).Debug("[CreateJSONData]")
 
 	var jsonData map[string]string
 	var ss []string
@@ -58,7 +64,11 @@ func RestCall(uri string, bGet bool, payload string) []byte {
 	var client = &http.Client{}
 	var XHassioKey = os.Getenv("HASSIO_TOKEN")
 
-	log.Debugf("[RestCall]: url->'%s', GET->'%t', payload->'%s'\n", uri, bGet, payload)
+	log.WithFields(log.Fields{
+		"uri":     uri,
+		"bGet":    bGet,
+		"payload": payload,
+	}).Debug("[RestCall]")
 
 	if bGet {
 		request, err = http.NewRequest("GET", uri, nil)
@@ -83,7 +93,9 @@ func RestCall(uri string, bGet bool, payload string) []byte {
 		os.Exit(1)
 	}
 	data, _ := ioutil.ReadAll(response.Body)
-	log.Debugf("[RestCall]: ResponseBody->'%s'\n", string(data))
+	log.WithFields(log.Fields{
+		"data": data,
+	}).Debug("[RestCall]")
 
 	defer response.Body.Close()
 	return data
@@ -121,7 +133,10 @@ func DisplayOutput(data []byte, rawjson bool) {
 }
 
 func FilterProperties(data []byte, filter []string) []byte {
-	log.Debugf("[FilterProperties]: indata->'%s', filter->'%s'\n", string(data), filter)
+	log.WithFields(log.Fields{
+		"indata": string(data),
+		"filter": filter,
+	}).Debug("[FilterProperties]")
 
 	mymap := ByteArrayToMap(data)
 	mymapdata := mymap["data"].(map[string]interface{})
@@ -132,16 +147,24 @@ func FilterProperties(data []byte, filter []string) []byte {
 		}
 	}
 	rawjson, _ := json.Marshal(newmap)
-	log.Debugf("[FilterProperties]: outdata->'%s'\n", string(rawjson))
+	log.WithFields(log.Fields{
+		"outdata": string(rawjson),
+	}).Debug("[FilterProperties]")
 
 	return rawjson
 }
 
 // ExecCommand Used to execute the remote calls for each of the managing commands
 func ExecCommand(basepath string, endpoint string, serverOverride string, get bool, Options string, Filter string, RawJSON bool) {
-	log.Debugf("[ExecCommand]: basepath->'%s', endpoint->'%s', serverOverride->'%s', get->'%t', Options->'%s', Filter->'%s', RawJSON->'%t'\n",
-		basepath, endpoint, serverOverride, get, Options, Filter, RawJSON)
-
+	log.WithFields(log.Fields{
+		"basepath":       basepath,
+		"endpoint":       endpoint,
+		"serverOverride": serverOverride,
+		"get":            get,
+		"options":        Options,
+		"rawJSON":        RawJSON,
+		"filter":         Filter,
+	}).Debug("[ExecCommand]")
 	uri := GenerateURI(basepath, endpoint, serverOverride)
 	response := RestCall(uri, get, Options)
 	if Filter == "" {

--- a/command/helpers/common.go
+++ b/command/helpers/common.go
@@ -8,19 +8,16 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // HassioServer uri to connect to hass.io with
 const HassioServer = "hassio"
 
-// DebugEnabled set by global --debug (-d) flag
-var DebugEnabled = false
-
 // GenerateURI Creates the API URI from the server and the endpoint
 func GenerateURI(basepath string, endpoint string, serverOverride string) string {
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [GenerateURI]: basepath->'%s', endpoint->'%s', serverOverride->'%s'\n", basepath, endpoint, serverOverride)
-	}
+	log.Debugf("[GenerateURI]: basepath->'%s', endpoint->'%s', serverOverride->'%s'\n", basepath, endpoint, serverOverride)
 	var uri bytes.Buffer
 	uri.WriteString("http://")
 	if serverOverride != "" {
@@ -40,9 +37,8 @@ func GenerateURI(basepath string, endpoint string, serverOverride string) string
 }
 
 func CreateJSONData(data string) map[string]string {
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [CreateJSONData]: data->'%s'\n", data)
-	}
+	log.Debugf("[CreateJSONData]: data->'%s'\n", data)
+
 	var jsonData map[string]string
 	var ss []string
 	ss = strings.Split(data, ",")
@@ -62,9 +58,7 @@ func RestCall(uri string, bGet bool, payload string) []byte {
 	var client = &http.Client{}
 	var XHassioKey = os.Getenv("HASSIO_TOKEN")
 
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [RestCall]: url->'%s', GET->'%t', payload->'%s'\n", uri, bGet, payload)
-	}
+	log.Debugf("[RestCall]: url->'%s', GET->'%t', payload->'%s'\n", uri, bGet, payload)
 
 	if bGet {
 		request, err = http.NewRequest("GET", uri, nil)
@@ -89,9 +83,7 @@ func RestCall(uri string, bGet bool, payload string) []byte {
 		os.Exit(1)
 	}
 	data, _ := ioutil.ReadAll(response.Body)
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [RestCall]: ResponseBody->'%s'\n", string(data))
-	}
+	log.Debugf("[RestCall]: ResponseBody->'%s'\n", string(data))
 
 	defer response.Body.Close()
 	return data
@@ -129,9 +121,8 @@ func DisplayOutput(data []byte, rawjson bool) {
 }
 
 func FilterProperties(data []byte, filter []string) []byte {
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [FilterProperties]: indata->'%s', filter->'%s'\n", string(data), filter)
-	}
+	log.Debugf("[FilterProperties]: indata->'%s', filter->'%s'\n", string(data), filter)
+
 	mymap := ByteArrayToMap(data)
 	mymapdata := mymap["data"].(map[string]interface{})
 	newmap := make(map[string]interface{})
@@ -141,18 +132,16 @@ func FilterProperties(data []byte, filter []string) []byte {
 		}
 	}
 	rawjson, _ := json.Marshal(newmap)
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [FilterProperties]: outdata->'%s'\n", string(rawjson))
-	}
+	log.Debugf("[FilterProperties]: outdata->'%s'\n", string(rawjson))
+
 	return rawjson
 }
 
 // ExecCommand Used to execute the remote calls for each of the managing commands
 func ExecCommand(basepath string, endpoint string, serverOverride string, get bool, Options string, Filter string, RawJSON bool) {
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [ExecCommand]: basepath->'%s', endpoint->'%s', serverOverride->'%s', get->'%t', Options->'%s', Filter->'%s', RawJSON->'%t'\n",
-			basepath, endpoint, serverOverride, get, Options, Filter, RawJSON)
-	}
+	log.Debugf("[ExecCommand]: basepath->'%s', endpoint->'%s', serverOverride->'%s', get->'%t', Options->'%s', Filter->'%s', RawJSON->'%t'\n",
+		basepath, endpoint, serverOverride, get, Options, Filter, RawJSON)
+
 	uri := GenerateURI(basepath, endpoint, serverOverride)
 	response := RestCall(uri, get, Options)
 	if Filter == "" {

--- a/command/homeassistant.go
+++ b/command/homeassistant.go
@@ -40,8 +40,15 @@ func CmdHomeassistant(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	log.Debugf("[CmdHomeassistant]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
+	log.WithFields(log.Fields{
+		"action":         action,
+		"endpoint":       endpoint,
+		"serverOverride": serverOverride,
+		"get":            get,
+		"options":        Options,
+		"rawJSON":        RawJSON,
+		"filter":         Filter,
+	}).Debug("[CmdHomeassistant]")
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/homeassistant.go
+++ b/command/homeassistant.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -15,8 +16,6 @@ func CmdHomeassistant(c *cli.Context) {
 	endpoint := ""
 	serverOverride := ""
 	get := false
-	DebugEnabled := c.GlobalBool("debug")
-	helpers.DebugEnabled = DebugEnabled
 	Options := c.String("options")
 	RawJSON := c.Bool("rawjson")
 	Filter := c.String("filter")
@@ -41,10 +40,9 @@ func CmdHomeassistant(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [CmdHomeassistant]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-			action, endpoint, serverOverride, get, Options, RawJSON, Filter)
-	}
+	log.Debugf("[CmdHomeassistant]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
+		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
+
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)
 	}

--- a/command/host.go
+++ b/command/host.go
@@ -36,8 +36,15 @@ func CmdHost(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	log.Debugf("DEBUG [CmdHost]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
+	log.WithFields(log.Fields{
+		"action":         action,
+		"endpoint":       endpoint,
+		"serveroverride": serverOverride,
+		"get":            get,
+		"options":        Options,
+		"rawjson":        RawJSON,
+		"filter":         Filter,
+	}).Debug("[CmdHost]")
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/host.go
+++ b/command/host.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -15,8 +16,6 @@ func CmdHost(c *cli.Context) {
 	endpoint := ""
 	serverOverride := ""
 	get := false
-	DebugEnabled := c.GlobalBool("debug")
-	helpers.DebugEnabled = DebugEnabled
 	Options := c.String("options")
 	RawJSON := c.Bool("rawjson")
 	Filter := c.String("filter")
@@ -37,10 +36,8 @@ func CmdHost(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [CmdHost]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-			action, endpoint, serverOverride, get, Options, RawJSON, Filter)
-	}
+	log.Debugf("DEBUG [CmdHost]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
+		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/snapshots.go
+++ b/command/snapshots.go
@@ -15,8 +15,6 @@ func CmdSnapshots(c *cli.Context) {
 	endpoint := ""
 	serverOverride := ""
 	get := false
-	DebugEnabled := c.GlobalBool("debug")
-	helpers.DebugEnabled = DebugEnabled
 	Options := c.String("options")
 	RawJSON := c.Bool("rawjson")
 	Filter := c.String("filter")

--- a/command/supervisor.go
+++ b/command/supervisor.go
@@ -37,8 +37,15 @@ func CmdSupervisor(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	log.Debugf("[CmdSupervisor]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
+	log.WithFields(log.Fields{
+		"action":         action,
+		"endpoint":       endpoint,
+		"serveroverride": serverOverride,
+		"get":            get,
+		"options":        Options,
+		"rawjson":        RawJSON,
+		"filter":         Filter,
+	}).Debugf("[CmdSupervisor]")
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/command/supervisor.go
+++ b/command/supervisor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -15,8 +16,6 @@ func CmdSupervisor(c *cli.Context) {
 	endpoint := ""
 	serverOverride := ""
 	get := false
-	DebugEnabled := c.GlobalBool("debug")
-	helpers.DebugEnabled = DebugEnabled
 	Options := c.String("options")
 	RawJSON := c.Bool("rawjson")
 	Filter := c.String("filter")
@@ -38,10 +37,8 @@ func CmdSupervisor(c *cli.Context) {
 		os.Exit(3)
 	}
 
-	if DebugEnabled {
-		fmt.Fprintf(os.Stdout, "DEBUG [CmdSupervisor]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
-			action, endpoint, serverOverride, get, Options, RawJSON, Filter)
-	}
+	log.Debugf("[CmdSupervisor]: action->'%s', endpoint='%s', serverOverride->'%s', GET->'%t', options->'%s', rawjson->'%t', filter->'%s'\n",
+		action, endpoint, serverOverride, get, Options, RawJSON, Filter)
 
 	if endpoint != "" {
 		helpers.ExecCommand(HassioBasePath, endpoint, serverOverride, get, Options, Filter, RawJSON)

--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,10 @@ var GlobalFlags = []cli.Flag{
 		Name:  "debug, d",
 		Usage: "Prints Debug information",
 	},
+	cli.StringFlag{
+		Name:  "log-format",
+		Usage: "log format to use, valid options are text and json. Default is text",
+	},
 }
 
 // Commands holds the commands that are supported by the CLI

--- a/main.go
+++ b/main.go
@@ -3,10 +3,14 @@ package main
 import (
 	"os"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 func main() {
+
+	// Only log the warning severity or above.
+	log.SetLevel(log.WarnLevel)
 
 	app := cli.NewApp()
 	app.Name = Name
@@ -17,6 +21,12 @@ func main() {
 
 	app.Flags = GlobalFlags
 	app.Commands = Commands
+	app.Before = func(c *cli.Context) error {
+		if c.GlobalBool("debug") {
+			log.SetLevel(log.DebugLevel)
+		}
+		return nil
+	}
 	app.CommandNotFound = CommandNotFound
 
 	app.Run(os.Args)

--- a/main.go
+++ b/main.go
@@ -25,6 +25,13 @@ func main() {
 		if c.GlobalBool("debug") {
 			log.SetLevel(log.DebugLevel)
 		}
+		switch logformat := c.GlobalString("log-format"); logformat {
+		case "json":
+			log.SetFormatter(&log.JSONFormatter{})
+		case "text":
+		default:
+			log.SetFormatter(&log.TextFormatter{})
+		}
 		return nil
 	}
 	app.CommandNotFound = CommandNotFound


### PR DESCRIPTION
Fix for #110 

This is an initial change to convert the Printf bases logoutput to logrus. With as end goal the ability to use the cli with json logging format for easier integration in other tools. For step 1 i converted all the debug statements. 

Further work:
- move errors to logrus as well, insteda of the fprintf
