### PR TITLE
Remove deprecated golang 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   - go: '1.7'
   - go: '1.9'
   - go: '1.10'
+  - go: '1.11'
   - go: '1.10'
     env: LINTER
     install: go get -u github.com/golang/lint/golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ go_import_path: github.com/home-assistant/hassio-cli
 matrix:
   fast_finish: true
   include:
-  - go: '1.6'
   - go: '1.7'
   - go: '1.9'
   - go: '1.10'


### PR DESCRIPTION
This fixes #114 

Also added golang 1.11 because it is the latest release, if that is an issue, i'll drop the commit