### PR TITLE
Add url processing to urlgenerator

### DIFF
--- a/command/helpers/common_test.go
+++ b/command/helpers/common_test.go
@@ -32,6 +32,20 @@ func TestGenerateUriEmptyEndpoint(t *testing.T) {
 		t.Errorf("URI incorrect, got: %s, want: %s.", uri, expectedURI)
 	}
 }
+func TestGenerateUriFullDefinedEndpoint(t *testing.T) {
+	expectedURI := "https://testme:433/api"
+	uri := GenerateURI("api", "", "https://testme:433")
+	if uri != expectedURI {
+		t.Errorf("URI incorrect, got: %s, want: %s.", uri, expectedURI)
+	}
+}
+func TestGenerateUriUncleanEndpoint(t *testing.T) {
+	expectedURI := "http://hassio/endpoint"
+	uri := GenerateURI("api/", "../endpoint", "hassio")
+	if uri != expectedURI {
+		t.Errorf("URI incorrect, got: %s, want: %s.", uri, expectedURI)
+	}
+}
 
 func TestCreateJSONData(t *testing.T) {
 	expectedVersion := "0.23"


### PR DESCRIPTION
Add postprocessing on the url
- add http scheme if it is missing from the url instead of hardcoding it
- cleanup path component
- HASSIO env variable could now contains a fully qualified url instead of only a hostname
