### PR TITLE
WIP Refactor to use the Cobra CLI

### DIFF
--- a/cmd/addons.go
+++ b/cmd/addons.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// addonsCmd represents the addons command
+var addonsCmd = &cobra.Command{
+	Use:   "addons",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("addons called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(addonsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// addonsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// addonsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/hassos.go
+++ b/cmd/hassos.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// hassosCmd represents the hassos command
+var hassosCmd = &cobra.Command{
+	Use:   "hassos",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("hassos called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(hassosCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// hassosCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// hassosCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/homeassistant.go
+++ b/cmd/homeassistant.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// homeassistantCmd represents the homeassistant command
+var homeassistantCmd = &cobra.Command{
+	Use:   "homeassistant",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("homeassistant called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(homeassistantCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// homeassistantCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// homeassistantCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/host.go
+++ b/cmd/host.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// hostCmd represents the host command
+var hostCmd = &cobra.Command{
+	Use:   "host",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("host called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(hostCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// hostCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// hostCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,8 @@ import (
 )
 
 var cfgFile string
+var debug bool = false
+var logFormat string = "text"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -31,6 +33,9 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.homeassistant.yaml)")
+	rootCmd.PersistentFlags().StringVarP(&logFormat, "log-format", "", logFormat, "log format to use, valid options are text and json. Default is text")
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", debug, "Prints Debug information")
+
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "hassio",
+	Short: "A brief description of your application",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("hassio")
+	},
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.homeassistant.yaml)")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Search config in home directory with name ".homeassistant" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".homeassistant.yaml")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,8 +10,8 @@ import (
 )
 
 var cfgFile string
-var debug bool = false
-var logFormat string = "text"
+var debug = false
+var logFormat = "text"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/snapshots.go
+++ b/cmd/snapshots.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// snapshotsCmd represents the snapshots command
+var snapshotsCmd = &cobra.Command{
+	Use:   "snapshots",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("snapshots called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(snapshotsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// snapshotsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// snapshotsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/snapshotsInfo.go
+++ b/cmd/snapshotsInfo.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// snapshotsInfoCmd represents the info subcommand for snapshots
+var snapshotsInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("info called")
+	},
+}
+
+func init() {
+	snapshotsCmd.AddCommand(snapshotsInfoCmd)
+}

--- a/cmd/snapshotsList.go
+++ b/cmd/snapshotsList.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// snapshotsListCmd represents the list subcommand for snapshots
+var snapshotsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("list called")
+	},
+}
+
+func init() {
+	snapshotsCmd.AddCommand(snapshotsListCmd)
+}

--- a/cmd/snapshotsNew.go
+++ b/cmd/snapshotsNew.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// snapshotsNewCmd represents the new subcommand for snapshots
+var snapshotsNewCmd = &cobra.Command{
+	Use:   "new",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("new called")
+	},
+}
+
+func init() {
+	snapshotsCmd.AddCommand(snapshotsNewCmd)
+}

--- a/cmd/snapshotsReload.go
+++ b/cmd/snapshotsReload.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// snapshotsReloadCmd represents the reload subcommand for snapshots
+var snapshotsReloadCmd = &cobra.Command{
+	Use:   "reload",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("reload called")
+	},
+}
+
+func init() {
+	snapshotsCmd.AddCommand(snapshotsReloadCmd)
+}

--- a/cmd/snapshotsRemove.go
+++ b/cmd/snapshotsRemove.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// snapshotsRemoveCmd represents the remove subcommand for snapshots
+var snapshotsRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("remove called")
+	},
+}
+
+func init() {
+	snapshotsCmd.AddCommand(snapshotsRemoveCmd)
+}

--- a/cmd/snapshotsRestore.go
+++ b/cmd/snapshotsRestore.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// snapshotsRestoreCmd represents the restore subcommand for snapshots
+var snapshotsRestoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("restore called")
+	},
+}
+
+func init() {
+	snapshotsCmd.AddCommand(snapshotsRestoreCmd)
+}

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -8,7 +8,7 @@ import (
 )
 
 var supervisorOpts string
-var supervisorRawJSON bool = false
+var supervisorRawJSON = false
 var supervisorFilter string
 
 // supervisorCmd represents the supervisor command

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -2,14 +2,20 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
 
+var supervisorOpts string
+var supervisorRawJSON bool = false
+var supervisorFilter string
+
 // supervisorCmd represents the supervisor command
 var supervisorCmd = &cobra.Command{
-	Use:   "supervisor",
-	Short: "A brief description of your command",
+	Use:     "supervisor",
+	Aliases: []string{"su"},
+	Short:   "A brief description of your command",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "No valid action detected.\n")
 		os.Exit(3)
@@ -19,13 +25,7 @@ var supervisorCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(supervisorCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// supervisorCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// supervisorCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	supervisorCmd.PersistentFlags().StringVarP(&supervisorOpts, "options", "o", supervisorOpts, "holds data for POST in format `key=val,key2=val2`")
+	supervisorCmd.PersistentFlags().StringVarP(&supervisorFilter, "filter", "f", supervisorFilter, "properties to extract from returned data `prop1,prop2`")
+	supervisorCmd.PersistentFlags().BoolVarP(&supervisorRawJSON, "rawjson", "j", supervisorRawJSON, "Returns the output in JSON format")
 }

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// supervisorCmd represents the supervisor command
+var supervisorCmd = &cobra.Command{
+	Use:   "supervisor",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Fprintf(os.Stderr, "No valid action detected.\n")
+		os.Exit(3)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(supervisorCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// supervisorCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// supervisorCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/supervisorInfo.go
+++ b/cmd/supervisorInfo.go
@@ -1,36 +1,34 @@
 package cmd
 
 import (
-	"fmt"
-        "os"
-
-	"github.com/spf13/cobra"
-	log "github.com/sirupsen/logrus"
 	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
-// infoCmd represents the info command
-var infoCmd = &cobra.Command{
+// supervisorInfoCmd represents the info subcommand for supervisor
+var supervisorInfoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "A brief description of your command",
 	Run: func(cmd *cobra.Command, args []string) {
 		basePath := "supervisor"
 		endpoint := "info"
 		get := true
-		
+		serverOverride := ""
+
+		log.WithFields(log.Fields{
+			"basepath":       basePath,
+			"endpoint":       endpoint,
+			"serverOverride": serverOverride,
+			"get":            get,
+			"options":        supervisorOpts,
+			"rawJSON":        supervisorRawJSON,
+			"filter":         supervisorFilter,
+		}).Debug("[CmdSupervisor]")
+		helpers.ExecCommand(basePath, endpoint, serverOverride, get, supervisorOpts, supervisorFilter, supervisorRawJSON)
 	},
 }
 
 func init() {
-	supervisor.AddCommand(infoCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// infoCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	supervisorCmd.AddCommand(supervisorInfoCmd)
 }

--- a/cmd/supervisorInfo.go
+++ b/cmd/supervisorInfo.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+        "os"
+
+	"github.com/spf13/cobra"
+	log "github.com/sirupsen/logrus"
+	"github.com/home-assistant/hassio-cli/command/helpers"
+)
+
+// infoCmd represents the info command
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		basePath := "supervisor"
+		endpoint := "info"
+		get := true
+		
+	},
+}
+
+func init() {
+	supervisor.AddCommand(infoCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// infoCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/supervisorLogs.go
+++ b/cmd/supervisorLogs.go
@@ -1,28 +1,34 @@
-import (
-	"fmt"
+package cmd
 
+import (
+	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// logsCmd represents the logs command
-var logsCmd = &cobra.Command{
+// supervisorLogsCmd represents the logs subcommand for supervisor
+var supervisorLogsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "A brief description of your command",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("logs called")
+		basePath := "supervisor"
+		endpoint := "logs"
+		get := true
+		serverOverride := ""
+
+		log.WithFields(log.Fields{
+			"basepath":       basePath,
+			"endpoint":       endpoint,
+			"serverOverride": serverOverride,
+			"get":            get,
+			"options":        supervisorOpts,
+			"rawJSON":        supervisorRawJSON,
+			"filter":         supervisorFilter,
+		}).Debug("[CmdSupervisor]")
+		helpers.ExecCommand(basePath, endpoint, serverOverride, get, supervisorOpts, supervisorFilter, supervisorRawJSON)
 	},
 }
 
 func init() {
-	supervisor.AddCommand(logsCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// logsCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// logsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	supervisorCmd.AddCommand(supervisorLogsCmd)
 }

--- a/cmd/supervisorLogs.go
+++ b/cmd/supervisorLogs.go
@@ -1,0 +1,28 @@
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// logsCmd represents the logs command
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "A brief description of your command",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("logs called")
+	},
+}
+
+func init() {
+	supervisor.AddCommand(logsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// logsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// logsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/supervisorOptions.go
+++ b/cmd/supervisorOptions.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// optionsCmd represents the options command
+var optionsCmd = &cobra.Command{
+	Use:   "options",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("options called")
+	},
+}
+
+func init() {
+	supervisor.AddCommand(optionsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// optionsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// optionsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/supervisorOptions.go
+++ b/cmd/supervisorOptions.go
@@ -1,50 +1,34 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// optionsCmd represents the options command
-var optionsCmd = &cobra.Command{
+// supervisorOptionsCmd represents the options subcommand for supervisor
+var supervisorOptionsCmd = &cobra.Command{
 	Use:   "options",
 	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("options called")
+		basePath := "supervisor"
+		endpoint := "info"
+		get := false
+		serverOverride := ""
+
+		log.WithFields(log.Fields{
+			"basepath":       basePath,
+			"endpoint":       endpoint,
+			"serverOverride": serverOverride,
+			"get":            get,
+			"options":        supervisorOpts,
+			"rawJSON":        supervisorRawJSON,
+			"filter":         supervisorFilter,
+		}).Debug("[CmdSupervisor]")
+		helpers.ExecCommand(basePath, endpoint, serverOverride, get, supervisorOpts, supervisorFilter, supervisorRawJSON)
 	},
 }
 
 func init() {
-	supervisor.AddCommand(optionsCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// optionsCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// optionsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	supervisorCmd.AddCommand(supervisorOptionsCmd)
 }

--- a/cmd/supervisorReload.go
+++ b/cmd/supervisorReload.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// reloadCmd represents the reload command
+var reloadCmd = &cobra.Command{
+	Use:   "reload",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("reload called")
+	},
+}
+
+func init() {
+	supervisor.AddCommand(reloadCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// reloadCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// reloadCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/supervisorReload.go
+++ b/cmd/supervisorReload.go
@@ -1,50 +1,34 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// reloadCmd represents the reload command
-var reloadCmd = &cobra.Command{
+// supervisorReloadCmd represents the reload subcommand for supervisor
+var supervisorReloadCmd = &cobra.Command{
 	Use:   "reload",
 	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("reload called")
+		basePath := "supervisor"
+		endpoint := "info"
+		get := false
+		serverOverride := ""
+
+		log.WithFields(log.Fields{
+			"basepath":       basePath,
+			"endpoint":       endpoint,
+			"serverOverride": serverOverride,
+			"get":            get,
+			"options":        supervisorOpts,
+			"rawJSON":        supervisorRawJSON,
+			"filter":         supervisorFilter,
+		}).Debug("[CmdSupervisor]")
+		helpers.ExecCommand(basePath, endpoint, serverOverride, get, supervisorOpts, supervisorFilter, supervisorRawJSON)
 	},
 }
 
 func init() {
-	supervisor.AddCommand(reloadCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// reloadCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// reloadCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	supervisorCmd.AddCommand(supervisorReloadCmd)
 }

--- a/cmd/supervisorUpdate.go
+++ b/cmd/supervisorUpdate.go
@@ -1,50 +1,34 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/home-assistant/hassio-cli/command/helpers"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// updateCmd represents the update command
-var updateCmd = &cobra.Command{
+// supervisorUpdateCmd represents the update subcommand for supervisor
+var supervisorUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("update called")
+		basePath := "supervisor"
+		endpoint := "update"
+		get := false
+		serverOverride := ""
+
+		log.WithFields(log.Fields{
+			"basepath":       basePath,
+			"endpoint":       endpoint,
+			"serverOverride": serverOverride,
+			"get":            get,
+			"options":        supervisorOpts,
+			"rawJSON":        supervisorRawJSON,
+			"filter":         supervisorFilter,
+		}).Debug("[CmdSupervisor]")
+		helpers.ExecCommand(basePath, endpoint, serverOverride, get, supervisorOpts, supervisorFilter, supervisorRawJSON)
 	},
 }
 
 func init() {
-	supervisor.AddCommand(updateCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// updateCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// updateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	supervisorCmd.AddCommand(supervisorUpdateCmd)
 }

--- a/cmd/supervisorUpdate.go
+++ b/cmd/supervisorUpdate.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("update called")
+	},
+}
+
+func init() {
+	supervisor.AddCommand(updateCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// updateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// updateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/hassio.bash
+++ b/hassio.bash
@@ -3,7 +3,7 @@
 _hassio()
 {
     local cur=${COMP_WORDS[COMP_CWORD]} prev=${COMP_WORDS[COMP_CWORD-1]}
-    local -a cmds=(homeassistant supervisor host hardware network snapshots
+    local -a cmds=(homeassistant supervisor host hassos hardware snapshots
                    addons help)
     local -a opts
     local i cmd action
@@ -51,7 +51,13 @@ _hassio()
         host|ho)
             case $cur in
                 -*) opts=(--rawjson --options --filter --help) ;;
-                *)  [[ -z $action ]] && opts=(reboot shutdown update) ;;
+                *)  [[ -z $action ]] && opts=(reboot shutdown) ;;
+            esac
+            ;;
+        hassos|os)
+            case $cur in
+                -*) opts=(--rawjson --options --filter --help) ;;
+                *)  [[ -z $action ]] && opts=(info update) ;;
             esac
             ;;
         hardware|hw)

--- a/main.go
+++ b/main.go
@@ -1,23 +1,9 @@
 package main
 
 import (
-	"os"
-
-	"github.com/urfave/cli"
+	"github.com/home-assistant/hassio-cli/cmd"
 )
 
 func main() {
-
-	app := cli.NewApp()
-	app.Name = Name
-	app.Version = Version
-	app.Author = "Home-Assistant"
-	app.Email = "hello@home-assistant.io"
-	app.Usage = "Commandline tool to allow interaction with hass.io"
-
-	app.Flags = GlobalFlags
-	app.Commands = Commands
-	app.CommandNotFound = CommandNotFound
-
-	app.Run(os.Args)
+	cmd.Execute()
 }

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@ package main
 const Name string = "hassio"
 
 // Version the current version of the CLI
-const Version string = "1.4.0"
+const Version string = "2.0.0"


### PR DESCRIPTION
_Massive_ refactor and I'll rebase back. Submitting for early review and to get feedback on "directional accuracy."

The idea is that, like the issue originally stated, each top level command would get its own directory. This is further required by the fact that many of the subcommands each in turn has (or will have) its own subcommands that share a name.

To do this with Cobra, we treat each top level subcommand as its own app, import them in the new `cmd` directory, and call them from there.

Examples of this plan in action:

```
go run ./main.go --help
A brief description of your application

Usage:
  hassio [flags]
  hassio [command]

Available Commands:
  addons        
  hardware      A brief description of your command
  hassos        A brief description of your command
  help          Help about any command
  homeassistant A brief description of your command
  host          A brief description of your command
  snapshots     A brief description of your command
  supervisor    A brief description of your command

Flags:
      --config string   config file (default is $HOME/.homeassistant.yaml)
  -h, --help            help for hassio
```

```
go run ./main.go addons
addons sub-command
```

And of course, our aliases work.
```
go run ./main.go ad
addons sub-command
```