### PR TITLE
Add check for empty response

### DIFF
--- a/command/helpers/common.go
+++ b/command/helpers/common.go
@@ -178,4 +178,7 @@ func ExecCommand(basepath string, endpoint string, serverOverride string, get bo
 	if responseMap["result"] != "ok" {
 		os.Exit(10)
 	}
+	if responseMap["ResponseBody"] == "" {
+		os.Exit(10)
+	}
 }


### PR DESCRIPTION
Check for an empty payload in the response so we don't inexplicably crash on invalid JSON later

I think this should solve #82 