### PR TITLE
Take binary name from running command instead of hardcoded value

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path"
 	"strings"
 
 	"github.com/home-assistant/hassio-cli/client"
@@ -20,7 +22,7 @@ var rawJSON bool
 var ExitWithError = false
 
 var rootCmd = &cobra.Command{
-	Use:   "hassio-cli",
+	Use:   path.Base(os.Args[0]),
 	Short: "A brief description of your application",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 


### PR DESCRIPTION
This fixes #140 by looking at the name of the binary used to invoke the
cli.

as side effect, the completion and help contain the whatever used to
invoke the binary, using go run for example with use the name `main`