### PR TITLE
Only set add-on repositories when at least 1 is given

### DIFF
--- a/cmd/supervisor_options.go
+++ b/cmd/supervisor_options.go
@@ -51,7 +51,7 @@ var supervisorOptionsCmd = &cobra.Command{
 		repos, err := cmd.Flags().GetStringArray("repositories")
 		log.WithField("repositories", repos).Debug("repos")
 
-		if len(repos) >= 0 && err == nil {
+		if len(repos) >= 1 && err == nil {
 			options["addons_repositories"] = repos
 		}
 


### PR DESCRIPTION
Currently, the CLI sends in an empty add-on repository array on changing supervisor options (without specifying repository flags).

This works around that issue by requiring at least one repositories argument before the array is sent to the API.