### PR TITLE
Adds support for generating ZSH completion script

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -9,21 +9,32 @@ import (
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
 	Use:   "completion",
-	Short: "Generates bash completion scripts",
+	Short: "Generates bash/zsh completion scripts",
 	Long: `To load completion run
 
-. <(hassio-cli completion)
+For Bash: . <(hassio-cli completion)
+For ZSH: . <(hassio-cli completion --zsh)
 
 To configure your bash shell to load completions for each session add to your bashrc
 
-# ~/.bashrc , ~/.profile or ~/.zshrc
+# ~/.bashrc , ~/.profile
 . <(hassio-cli completion)
+
+# ~/.zshrc
+. <(hassio-cli completion --zsh)
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.GenBashCompletion(os.Stdout)
+
+		_, err := cmd.Flags().GetBool("zsh")
+		if err == nil && cmd.Flags().Changed("zsh") {
+			rootCmd.GenZshCompletion(os.Stdout)
+		} else {
+			rootCmd.GenBashCompletion(os.Stdout)
+		}
 	},
 }
 
 func init() {
+	completionCmd.Flags().Bool("zsh", false, "Generate ZSH completion script")
 	rootCmd.AddCommand(completionCmd)
 }


### PR DESCRIPTION
Currently, the CLI supports generating a Bash completion script. This also works for ZSH, however, Cobra is also capable of a more compatible/specific completion script for ZSH.

This PR adds that capability by introducing an additional flag.

For Bash: `hassio completion`
For ZSH:  `hassio completion --zsh`
