### PR TITLE
Adds processing spinner and improves command completed message

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -122,7 +122,7 @@ func ShowJSONResponse(resp *resty.Response) (success bool) {
 	if data.Result == "ok" {
 		success = true
 		if len(data.Data) == 0 {
-			fmt.Println("ok")
+			fmt.Println("Command completed successfully.")
 		} else {
 			j, err := json.Marshal(data.Data)
 			if err != nil {

--- a/cmd/addons_install.go
+++ b/cmd/addons_install.go
@@ -45,7 +45,9 @@ This command allows you to install a Hass.io add-on from the commandline.
 			"slug": slug,
 		})
 
+		ProgressSpinner.Start()
 		resp, err := request.Post(url)
+		ProgressSpinner.Stop()
 
 		// returns 200 OK or 400, everything else is wrong
 		if err == nil {

--- a/cmd/addons_rebuild.go
+++ b/cmd/addons_rebuild.go
@@ -48,7 +48,9 @@ add-on.
 			"slug": slug,
 		})
 
+		ProgressSpinner.Start()
 		resp, err := request.Post(url)
+		ProgressSpinner.Stop()
 
 		// returns 200 OK or 400, everything else is wrong
 		if err == nil {

--- a/cmd/addons_reload.go
+++ b/cmd/addons_reload.go
@@ -29,7 +29,10 @@ is released, but not yet available as an upgrade on your Hass.io dashboard.
 		command := "reload"
 		base := viper.GetString("endpoint")
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		ProgressSpinner.Stop()
+
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/addons_update.go
+++ b/cmd/addons_update.go
@@ -38,7 +38,9 @@ It is currently not possible to upgrade/downgrade to a specific version.
 			return
 		}
 
+		ProgressSpinner.Start()
 		request := helper.GetJSONRequest()
+		ProgressSpinner.Stop()
 
 		slug := args[0]
 

--- a/cmd/dns_update.go
+++ b/cmd/dns_update.go
@@ -34,7 +34,10 @@ to the latest version or the version specified.
 			options = map[string]interface{}{"version": version}
 		}
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, options)
+		ProgressSpinner.Stop()
+
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/hassos_update.go
+++ b/cmd/hassos_update.go
@@ -35,7 +35,9 @@ to the latest version or the version specified.
 			options = map[string]interface{}{"version": version}
 		}
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, options)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/hassos_update_cli.go
+++ b/cmd/hassos_update_cli.go
@@ -34,7 +34,9 @@ version or the version specified.
 			options = map[string]interface{}{"version": version}
 		}
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, options)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/homeassistant_check.go
+++ b/cmd/homeassistant_check.go
@@ -26,8 +26,11 @@ Home Assistant.`,
 		section := "homeassistant"
 		command := "check"
 		base := viper.GetString("endpoint")
-
+		
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		ProgressSpinner.Stop()
+		
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/homeassistant_rebuild.go
+++ b/cmd/homeassistant_rebuild.go
@@ -25,7 +25,9 @@ running on your Hass.io system. Don't worry, this does not delete your config.`,
 		command := "rebuild"
 		base := viper.GetString("endpoint")
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/homeassistant_restart.go
+++ b/cmd/homeassistant_restart.go
@@ -24,7 +24,9 @@ Restart the Home Assistant instance running on your Hass.io system`,
 		command := "restart"
 		base := viper.GetString("endpoint")
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/homeassistant_start.go
+++ b/cmd/homeassistant_start.go
@@ -25,7 +25,9 @@ Hass.io system. This, of course, only applies when it has been stopped.`,
 		command := "start"
 		base := viper.GetString("endpoint")
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/homeassistant_stop.go
+++ b/cmd/homeassistant_stop.go
@@ -25,7 +25,9 @@ Hass.io system.`,
 		command := "stop"
 		base := viper.GetString("endpoint")
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/homeassistant_update.go
+++ b/cmd/homeassistant_update.go
@@ -33,7 +33,9 @@ running on your Hass.io system to the latest version or the version specified.`,
 			options = map[string]interface{}{"version": version}
 		}
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, options)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/snapshots_new.go
+++ b/cmd/snapshots_new.go
@@ -56,7 +56,9 @@ containing a backup of your Hass.io system.`,
 			command = "new/partial"
 		}
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, options)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/snapshots_restore.go
+++ b/cmd/snapshots_restore.go
@@ -79,7 +79,9 @@ take Hass.io snapshot backup on your system.`,
 			request.SetBody(options)
 		}
 
+		ProgressSpinner.Start()
 		resp, err := request.Post(url)
+		ProgressSpinner.Stop()
 
 		// returns 200 OK or 400, everything else is wrong
 		if err == nil {

--- a/cmd/supervisor_repair.go
+++ b/cmd/supervisor_repair.go
@@ -27,7 +27,9 @@ WARNING! This command is currently in beta.`,
 		command := "repair"
 		base := viper.GetString("endpoint")
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/supervisor_update.go
+++ b/cmd/supervisor_update.go
@@ -33,7 +33,9 @@ running on your Hass.io system to the latest version or the version specified.`,
 			options = map[string]interface{}{"version": version}
 		}
 
+		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPost(base, section, command, options)
+		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/home-assistant/hassio-cli
 go 1.12
 
 require (
+	github.com/briandowns/spinner v1.6.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-resty/resty/v2 v2.0.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/briandowns/spinner v1.6.1 h1:LBxHu5WLyVuVEtTD72xegiC7QJGx598LBpo3ywKTapA=
+github.com/briandowns/spinner v1.6.1/go.mod h1://Zf9tMcxfRUA36V23M6YGEAv+kECGfvpnLTnb8n4XQ=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -21,6 +23,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -66,6 +70,10 @@ github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDe
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -155,6 +163,7 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1YthsFqr/5mxHduZW2A=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -140,7 +140,10 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
+golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -148,6 +151,7 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH9uqVPRCUVUDhs0wnbA=
@@ -164,6 +168,7 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
- Adds a little spinner, to show we are busy.
  * Spinner is written to StdErr, so the redirected output is not affected
  * Spinner writes to a nulled buffer when not in TTY
  * Adds `--no-progress` global flag, to force disable spinner
  * Spinner is only added to commands that are known to take a little longer (e.g. update, install, new snapshots)
- Instead of a simple "ok" message, I've replaced the success message with the more friendly: "Command completed successfully."


![2019-08-14 21 35 54](https://user-images.githubusercontent.com/195327/63050492-8df0e200-bedb-11e9-8209-b58073c857e7.gif)
