### PR TITLE
Fix progress spinner on Putty

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,15 +5,14 @@ import (
 	"path"
 	"strings"
 	"time"
-	"io/ioutil"
 
-	"github.com/briandowns/spinner"
 	"github.com/home-assistant/hassio-cli/client"
+	"github.com/home-assistant/hassio-cli/spinner"
+	homedir "github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh/terminal"
-	homedir "github.com/mitchellh/go-homedir"
-	log "github.com/sirupsen/logrus"
 )
 
 var cfgFile string
@@ -27,7 +26,7 @@ var noProgress bool
 var ExitWithError = false
 
 // ProgressSpinner is a general spinner that can be used across the CLI
-var ProgressSpinner = spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+var ProgressSpinner = spinner.New(spinner.CharSets[0], 125*time.Millisecond)
 
 var rootCmd = &cobra.Command{
 	Use:   path.Base(os.Args[0]),
@@ -53,19 +52,19 @@ control and configure different aspects of Hass.io`,
 		}
 
 		log.WithFields(log.Fields{
-			"apiToken": viper.GetString("api-token"),
-			"cfgFile":  viper.GetString("config"),
-			"endpoint": viper.GetString("endpoint"),
-			"logLevel": viper.GetString("log-level"),
+			"apiToken":   viper.GetString("api-token"),
+			"cfgFile":    viper.GetString("config"),
+			"endpoint":   viper.GetString("endpoint"),
+			"logLevel":   viper.GetString("log-level"),
 			"noProgress": viper.GetBool("no-progress"),
-			"rawJSON":  viper.GetBool("raw-json"),
+			"rawJSON":    viper.GetBool("raw-json"),
 		}).Debugln("Debug flags")
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if (ProgressSpinner.Active()) {
+		if ProgressSpinner.Active() {
 			ProgressSpinner.Stop()
 		}
-	},	
+	},
 }
 
 // Execute represents the entrypoint for when called without any subcommand
@@ -100,7 +99,6 @@ func init() {
 	// Configure global spinner
 	ProgressSpinner.Suffix = " Processing..."
 	ProgressSpinner.FinalMSG = "Processing... Done.\n\n"
-	ProgressSpinner.Writer = ioutil.Discard
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,9 @@ module github.com/home-assistant/hassio-cli
 go 1.12
 
 require (
-	github.com/briandowns/spinner v1.8.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-resty/resty/v2 v2.1.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -7,12 +7,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-github.com/briandowns/spinner v1.6.1 h1:LBxHu5WLyVuVEtTD72xegiC7QJGx598LBpo3ywKTapA=
-github.com/briandowns/spinner v1.6.1/go.mod h1://Zf9tMcxfRUA36V23M6YGEAv+kECGfvpnLTnb8n4XQ=
-github.com/briandowns/spinner v1.7.0 h1:aan1hBBOoscry2TXAkgtxkJiq7Se0+9pt+TUWaPrB4g=
-github.com/briandowns/spinner v1.7.0/go.mod h1://Zf9tMcxfRUA36V23M6YGEAv+kECGfvpnLTnb8n4XQ=
-github.com/briandowns/spinner v1.8.0 h1:SeidJ8ASAayR4Wxl5Of54LHqgi8s6sBvAHg4kxKxia4=
-github.com/briandowns/spinner v1.8.0/go.mod h1://Zf9tMcxfRUA36V23M6YGEAv+kECGfvpnLTnb8n4XQ=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -27,8 +21,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -36,8 +28,6 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-resty/resty/v2 v2.0.0 h1:9Nq/U+V4xsoDnDa/iTrABDWUCuk3Ne92XFHPe6dKWUc=
-github.com/go-resty/resty/v2 v2.0.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-resty/resty/v2 v2.1.0 h1:Z6IefCpUMfnvItVJaJXWv/pMiiD11So35QgwEELsldE=
 github.com/go-resty/resty/v2 v2.1.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -50,6 +40,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -60,6 +51,7 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -78,10 +70,6 @@ github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDe
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
-github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -110,7 +98,9 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -130,10 +120,6 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
-github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
-github.com/spf13/viper v1.5.0 h1:GpsTwfsQ27oS/Aha/6d1oD7tpKIqWnOA6tgOX9HHkt4=
-github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1 h1:VPZzIkznI1YhVMRi6vNFLHSwhnhReBfgTxIPccpfdZk=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -183,7 +169,6 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1YthsFqr/5mxHduZW2A=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=

--- a/spinner/character_sets.go
+++ b/spinner/character_sets.go
@@ -1,4 +1,4 @@
-// Originally created by Brian Downs
+// Package spinner Originally created by Brian Downs
 // https://github.com/briandowns/spinner
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/spinner/character_sets.go
+++ b/spinner/character_sets.go
@@ -1,0 +1,33 @@
+// Originally created by Brian Downs
+// https://github.com/briandowns/spinner
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spinner
+
+const (
+	clockOneOClock = '\U0001F550'
+	clockOneThirty = '\U0001F55C'
+)
+
+// CharSets contains the available character sets
+var CharSets = map[int][]string{
+	0: {"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"},
+	1: {"⢹", "⢺", "⢼", "⣸", "⣇", "⡧", "⡗", "⡏"},
+}
+
+func init() {
+	for i := rune(0); i < 12; i++ {
+		CharSets[37] = append(CharSets[37], string([]rune{clockOneOClock + i}))
+		CharSets[38] = append(CharSets[38], string([]rune{clockOneOClock + i}), string([]rune{clockOneThirty + i}))
+	}
+}

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -1,0 +1,185 @@
+// Originally created by Brian Downs
+// https://github.com/briandowns/spinner
+//
+// Stripped down and modified to work better for the Hass.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package spinner is a simple package to add a spinner / progress indicator to any terminal application.
+package spinner
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+// Spinner struct to hold the provided options
+type Spinner struct {
+	Delay      time.Duration // Delay is the speed of the indicator
+	chars      []string      // chars holds the chosen character set
+	Prefix     string        // Prefix is the text preppended to the indicator
+	Suffix     string        // Suffix is the text appended to the indicator
+	FinalMSG   string        // string displayed after Stop() is called
+	lastOutput string        // last character(set) written
+	lock       *sync.RWMutex //
+	Writer     io.Writer     // to make testing better, exported so users have access
+	active     bool          // active holds the state of the spinner
+	stopChan   chan struct{} // stopChan is a channel used to stop the indicator
+	HideCursor bool          // hideCursor determines if the cursor is visible
+}
+
+// New provides a pointer to an instance of Spinner with the supplied options
+func New(cs []string, d time.Duration, options ...Option) *Spinner {
+	s := &Spinner{
+		Delay:    d,
+		chars:    cs,
+		lock:     &sync.RWMutex{},
+		Writer:   ioutil.Discard,
+		active:   false,
+		stopChan: make(chan struct{}, 1),
+	}
+
+	for _, option := range options {
+		option(s)
+	}
+	return s
+}
+
+// Option is a function that takes a spinner and applies
+// a given configuration
+type Option func(*Spinner)
+
+// Options contains fields to configure the spinner
+type Options struct {
+	Suffix     string
+	FinalMSG   string
+	HideCursor bool
+}
+
+// WithFinalMSG adds the given string ot the spinner
+// as the final message to be written
+func WithFinalMSG(finalMsg string) Option {
+	return func(s *Spinner) {
+		s.FinalMSG = finalMsg
+	}
+}
+
+// WithHiddenCursor hides the cursor
+// if hideCursor = true given
+func WithHiddenCursor(hideCursor bool) Option {
+	return func(s *Spinner) {
+		s.HideCursor = hideCursor
+	}
+}
+
+// Active will return whether or not the spinner is currently active
+func (s *Spinner) Active() bool {
+	return s.active
+}
+
+// Start will start the indicator
+func (s *Spinner) Start() {
+	s.lock.Lock()
+	if s.active {
+		s.lock.Unlock()
+		return
+	}
+	s.active = true
+	s.lock.Unlock()
+
+	go func() {
+		for {
+			for i := 0; i < len(s.chars); i++ {
+				select {
+				case <-s.stopChan:
+					return
+				default:
+					s.lock.Lock()
+					s.erase()
+					if !s.active {
+						return
+					}
+					outPlain := fmt.Sprintf("%s%s%s ", s.Prefix, s.chars[i], s.Suffix)
+					fmt.Fprint(s.Writer, outPlain)
+					s.lastOutput = outPlain
+					delay := s.Delay
+					s.lock.Unlock()
+
+					time.Sleep(delay)
+				}
+			}
+		}
+	}()
+}
+
+// Stop stops the indicator
+func (s *Spinner) Stop() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.active {
+		s.active = false
+		s.erase()
+		if s.FinalMSG != "" {
+			fmt.Fprintf(s.Writer, s.FinalMSG)
+		}
+		s.stopChan <- struct{}{}
+	}
+}
+
+// Restart will stop and start the indicator
+func (s *Spinner) Restart() {
+	s.Stop()
+	s.Start()
+}
+
+// UpdateSpeed will set the indicator delay to the given value
+func (s *Spinner) UpdateSpeed(d time.Duration) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.Delay = d
+}
+
+// UpdateCharSet will change the current character set to the given one
+func (s *Spinner) UpdateCharSet(cs []string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.chars = cs
+}
+
+// erase deletes written characters
+//
+// Caller must already hold s.lock.
+func (s *Spinner) erase() {
+	n := utf8.RuneCountInString(s.lastOutput)
+	clearString := "\r"
+	for i := 0; i < n; i++ {
+		clearString += " "
+	}
+	clearString += "\r"
+	fmt.Fprintf(s.Writer, clearString)
+	s.lastOutput = ""
+}
+
+// Lock allows for manual control to lock the spinner
+func (s *Spinner) Lock() {
+	s.lock.Lock()
+}
+
+// Unlock allows for manual control to unlock the spinner
+func (s *Spinner) Unlock() {
+	s.lock.Unlock()
+}


### PR DESCRIPTION
Fixes #179 

Added own version of the Spinner. Slimmed it down in the process.

### Putty on Windows:

![2019-12-12 22 17 22](https://user-images.githubusercontent.com/195327/70749723-377e9d80-1d2d-11ea-845f-c96785ba3351.gif)

### iTerm2 on Mac:

![2019-12-12 22 18 58](https://user-images.githubusercontent.com/195327/70749850-7a407580-1d2d-11ea-8215-7fcf5714d7c7.gif)

### Terminal via HA frontend:

![2019-12-12 22 19 55](https://user-images.githubusercontent.com/195327/70749893-96dcad80-1d2d-11ea-8c79-a7bf7f742735.gif)


