### PR TITLE
Fix ZSH completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,15 +1,17 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"path"
 
 	"github.com/spf13/cobra"
 )
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generates bash/zsh completion scripts",
+	Use:    "completion",
+	Short:  "Generates bash/zsh completion scripts",
 	Hidden: true,
 	Long: `To load completion run
 
@@ -29,6 +31,16 @@ To configure your bash shell to load completions for each session add to your ba
 		_, err := cmd.Flags().GetBool("zsh")
 		if err == nil && cmd.Flags().Changed("zsh") {
 			rootCmd.GenZshCompletion(os.Stdout)
+
+			// Workaround for the missing compdef in spf13's Cobra
+			// ZSH completion generation.
+			os.Stdout.WriteString(
+				fmt.Sprintf(
+					"\ncompdef _%s %s\n",
+					path.Base(os.Args[0]),
+					path.Base(os.Args[0]),
+				),
+			)
 		} else {
 			rootCmd.GenBashCompletion(os.Stdout)
 		}


### PR DESCRIPTION
Fixes ZSH completion script.

The completion script generated by the Cobra library is missing a compdef at the end of the script.

This adds in a workaround that outputs the missing compdef after Cobra has generated it.
